### PR TITLE
Support Wish DM "screens"

### DIFF
--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -1,6 +1,6 @@
 import * as Koa from "koa";
 
-import { requireKey } from "../errors";
+import { AuthError, requireKey } from "../errors";
 import { logger } from "../log";
 import * as push from "../services/push";
 
@@ -10,6 +10,18 @@ export async function send(ctx: Koa.Context) {
     }
 
     logger.warn("No resource state provided with push attempt", {headers: ctx.headers});
+}
+
+export async function dm(ctx: Koa.Context) {
+    const sessionId = ctx.headers.Authorization;
+    if (!sessionId) {
+        throw new AuthError();
+    }
+
+    const event = requireKey(ctx.request, "body");
+
+    await push.sendDmEvent(sessionId, event);
+    ctx.status = 201;
 }
 
 async function sendGapi(ctx: Koa.Context) {

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -53,6 +53,7 @@ export async function create(ctx: Koa.Context): Promise<void> {
     const params = ctx.request.body as {
         auth: IAuth,
         ids: string[],
+        dm?: string,
     };
     requireKey(params, "auth");
     requireKey(params, "ids");
@@ -60,6 +61,7 @@ export async function create(ctx: Koa.Context): Promise<void> {
     const sessionId = await session.create(
         params.auth,
         params.ids,
+        params.dm,
     );
 
     // return the session ID so they can subscribe later

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -11,6 +11,7 @@ export function createRoutes() {
     const routes = new Router();
 
     routes.post("/push/send", push.send);
+    routes.post("/push/sessions/dm", push.dm);
 
     routes.post("/push/sessions", session.create);
     routes.get("/push/sessions/sse/:sessionId",

--- a/src/services/channels.ts
+++ b/src/services/channels.ts
@@ -5,11 +5,14 @@ import * as redis from "./redis";
 
 export enum EventId {
     Changed = "changed",
+    DM = "dm",
     NeedWatch = "need-watch",
 }
 
 export interface IChannelsService {
     sendChanged(sessionId: string, sheetId: string): void;
+
+    sendDmEvent(dmId: string, event: any): void;
 
     // tslint:disable-next-line:unified-signatures since the param moves
     sendNeedWatch(sessionId: string, sheetId?: string): void;
@@ -49,6 +52,10 @@ export class DistributedChannelsService implements IChannelsService {
         this.send(sessionId, EventId.Changed, {
             id: sheetId,
         });
+    }
+
+    public sendDmEvent(dmId: string, event: any): void {
+        this.send(dmId, EventId.DM, event);
     }
 
     public sendNeedWatch(sheetId: string): void;

--- a/src/services/provider/core.ts
+++ b/src/services/provider/core.ts
@@ -26,4 +26,6 @@ export interface IProvider<Auth> {
     ): Promise<any>;
 
     validate(auth: Auth): Promise<any> | never;
+
+    verifyCanEdit(auth: Auth, fileId: string): Promise<any>;
 }

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -1,5 +1,5 @@
 
-import { InputError, requireInput } from "../errors";
+import { AuthError, requireInput } from "../errors";
 import services from "../services";
 import * as redis from "../services/redis";
 
@@ -35,7 +35,7 @@ export async function sendDmEvent(sessionId: string, event: any) {
     const dmId = await redis.getClient().get(`dm:${sessionId}`);
     if (!dmId) {
         // no such DM session
-        throw new InputError("No such DM session");
+        throw new AuthError("No such DM session");
     }
 
     services.channels.sendDmEvent(dmId, event);

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -1,6 +1,7 @@
 
-import { requireInput } from "../errors";
+import { InputError, requireInput } from "../errors";
 import services from "../services";
+import * as redis from "../services/redis";
 
 /**
  * Webhook receiver for "changed" notifications from a Provider
@@ -18,4 +19,24 @@ export async function notifyChanged(channel: string, token: string) {
     // NOTE: anyone interested in this sheet is listening
     // on a channel named by the sheetId
     services.channels.sendChanged(sheetId, sheetId);
+}
+
+/**
+ * Send a DM event on the given sessionId
+ *
+ * @param sessionId ID of the DM session. This acts as a bearer token
+ *  in that whoever knows the session ID is assumed to be authorized
+ *  to use it.
+ */
+export async function sendDmEvent(sessionId: string, event: any) {
+    requireInput(sessionId, "sessionId");
+    requireInput(event, "event");
+
+    const dmId = await redis.getClient().get(`dm:${sessionId}`);
+    if (!dmId) {
+        // no such DM session
+        throw new InputError("No such DM session");
+    }
+
+    services.channels.sendDmEvent(dmId, event);
 }

--- a/test/services/push-test.ts
+++ b/test/services/push-test.ts
@@ -1,0 +1,38 @@
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+
+import { sendDmEvent } from "../../src/services/push";
+import { create } from "../../src/services/session";
+import { integrate } from "../test-integration";
+
+chai.use(chaiAsPromised);
+chai.should();
+
+describe("sendDmEvent", () => {
+    it("verifies DM session", integrate(async () => {
+        await sendDmEvent("no-such", { type: "any" })
+            .should.eventually.be.rejectedWith(/No such/);
+    }));
+
+    it("sends event for valid sessions", integrate(async ({ channels, provider }) => {
+        const ids = ["1", "2"];
+        const dmId = "gdrive/wdmid";
+
+        provider.inst.editableFiles.add("dmid");
+        const sessionId = await create(
+            {},
+            ids,
+            dmId,
+        );
+
+        await sendDmEvent(sessionId, { type: "any" });
+        channels.sent.should.deep.equal({
+            [dmId]: [
+                {
+                    data: { type: "any" },
+                    event: "dm",
+                },
+            ],
+        });
+    }));
+});

--- a/test/services/session-test.ts
+++ b/test/services/session-test.ts
@@ -100,4 +100,28 @@ describe("session service", () => {
         // ... no new messages should have be sent
         channels.sent.should.be.empty;
     }));
+
+    it("handles DM session requests", integrate(async ({ provider, redis }) => {
+        const ids = ["1", "2"];
+        const dmId = "gdrive/wdmid";
+
+        provider.inst.editableFiles.add("dmid");
+        const sessionId = await session.create({}, ids, dmId);
+
+        // if the session was created, we should also have set
+        // what sheet we're the DM of
+        const setDmId = redis.get(`dm:${sessionId}`);
+        await setDmId.should.eventually.equal(dmId);
+    }));
+
+    it("verifies DM session requests", integrate(async ({ provider, redis }) => {
+        const ids = ["1", "2"];
+        const dmId = "gdrive/wdmid";
+
+        // NOTE: above we add the fileId to editableFiles on the Fake.
+        // By skipping that, we simulate an auth error from that service
+
+        await session.create({}, ids, dmId)
+            .should.eventually.be.rejected;
+    }));
 });

--- a/test/test-integration.ts
+++ b/test/test-integration.ts
@@ -1,5 +1,6 @@
 import { createHandyClient, IHandyRedis } from "handy-redis";
 
+import { InputError } from "../src/errors";
 import services from "../src/services";
 import { AuthService } from "../src/services/auth";
 import { DistributedChannelsService, EventId } from "../src/services/channels";
@@ -39,6 +40,7 @@ class FakeTokenService implements ITokenService {
 export class FakeProvider implements IProvider<any> {
 
     public validateRequests: any[] = [];
+    public editableFiles = new Set<string>();
 
     public async watch(config: IWatchParams<any>, channelId: string, ttlSeconds: number): Promise<any> {
         // nop
@@ -49,13 +51,18 @@ export class FakeProvider implements IProvider<any> {
     public async validate(auth: any): Promise<any> {
         this.validateRequests.push(auth);
     }
+    public async verifyCanEdit(auth: any, fileId: string): Promise<any> {
+        if (!this.editableFiles.has(fileId)) {
+            throw new InputError(`Not authorized: ${fileId}`);
+        }
+    }
 }
 
 class FakeProviderService implements IProviderService {
 
     public readonly knownProviders: string[] = ["fake"];
 
-    private readonly inst = new FakeProvider();
+    public readonly inst = new FakeProvider();
 
     public byId(providerId: string): IProvider<any> {
         return this.inst;


### PR DESCRIPTION
When opening a DM screen file, Wish should include the `dm` property (pointing to the DM file) when creating the session. Then, it can POST `dm` events using the session ID in the `Authorization` header.